### PR TITLE
Fix OpenAI model initialization and text completion

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -11,9 +11,25 @@ class ModelInterface:
 
 
 class OpenAIModel(ModelInterface):
-    def __init__(self, api_key: str, model_engine: str, image_size: str = '512x512'):
+    def __init__(self, api_key: str, model_engine: str,
+                 max_tokens: int = 128, image_size: str = '512x512'):
+        """Initialize the OpenAI model helper.
+
+        Parameters
+        ----------
+        api_key: str
+            The OpenAI API key.
+        model_engine: str
+            The model id/engine to use for completions.
+        max_tokens: int, optional
+            Maximum number of tokens to generate for text completions.
+        image_size: str, optional
+            Size of generated images.
+        """
+
         openai.api_key = api_key
         self.model_engine = model_engine
+        self.max_tokens = max_tokens
         self.image_size = image_size
 
     def chat_completion(self, messages) -> str:
@@ -22,6 +38,17 @@ class OpenAIModel(ModelInterface):
             messages=messages
         )
         return response
+
+    def text_completion(self, prompt: str) -> str:
+        """Generate a text completion from a prompt."""
+        response = openai.Completion.create(
+            engine=self.model_engine,
+            prompt=prompt,
+            max_tokens=self.max_tokens,
+            stop=None,
+            temperature=0.5
+        )
+        return response.choices[0].text
 
     def image_generation(self, prompt: str) -> str:
         response = openai.Image.create(


### PR DESCRIPTION
## Summary
- add `max_tokens` to `OpenAIModel` constructor and store it
- implement a `text_completion` method for text-based completions
- update tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856cec01dc832890620f33a04b6dc3